### PR TITLE
Ajustar predicados y migrar a ES6

### DIFF
--- a/dist/axes.js
+++ b/dist/axes.js
@@ -1,6 +1,4 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-const THREE = require("three");
+import * as THREE from "three";
 // - - - - - - - - - - - - - Constantes - - - - - - - - - - - - -
 const AXE_LABEL_PADDING = 0.5;
 const AXE_TICK_PADDING = 0.3;
@@ -119,4 +117,4 @@ function linspace(a, b, n) {
     }
     return ret;
 }
-exports.default = Axes;
+export default Axes;

--- a/dist/export.js
+++ b/dist/export.js
@@ -1,9 +1,7 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
 const GIF = require("gif.js/dist/gif");
 const gif = new GIF({
     workers: 2,
     quality: 10
 });
 const Export = {};
-exports.default = Export;
+export default Export;

--- a/dist/figures-constants.js
+++ b/dist/figures-constants.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.REMOVE_VERTEX_PREDICATE = exports.VERTEX_CONFIGURATION = exports.MIN_QUALITY_TO_DISCRIMINATE_CIRCLE = exports.LINE_DASHED_MATERIAL = exports.LINE_BASIC_MATERIAL = exports.DODECAHEDRON_VERTICES = exports.ICOSACAHEDRON_VERTICES = exports.OCTAHEDRON_VERTICES = exports.CUBE_VERTICES = exports.TETRAHEDRON_VERTICES = exports.r = exports.t = void 0;
+exports.REMOVE_METADATA_PREDICATE = exports.REMOVE_VERTEX_PREDICATE = exports.REMOVE_EDGES_PREDICATE = exports.VERTEX_CONFIGURATION = exports.MIN_QUALITY_TO_DISCRIMINATE_CIRCLE = exports.LINE_DASHED_MATERIAL = exports.LINE_BASIC_MATERIAL = exports.DODECAHEDRON_VERTICES = exports.ICOSACAHEDRON_VERTICES = exports.OCTAHEDRON_VERTICES = exports.CUBE_VERTICES = exports.TETRAHEDRON_VERTICES = exports.r = exports.t = void 0;
 const three_1 = require("three");
 exports.t = (1 + Math.sqrt(5)) / 2;
 exports.r = 1 / exports.t;
@@ -158,6 +158,17 @@ exports.VERTEX_CONFIGURATION = new three_1.MeshLambertMaterial({
     opacity: 1,
     transparent: true
 });
+// Se puede dar el caso en que se está renderizando una figura agrupada, esto
+// sucede cuando se usa joinFigIn3D. Para ver si el Group correspondiente es
+// el de las aristas, se chequea el material del primer elemento.
+// De ser ese el caso, se borra todo el Group (ya que solo tiene aristas)
+const REMOVE_EDGES_PREDICATE = object3D => {
+    var _a, _b;
+    return object3D.type === "LineSegments" ||
+        (object3D.type === "Group" &&
+            ((_b = (_a = object3D.children[0]) === null || _a === void 0 ? void 0 : _a.material) === null || _b === void 0 ? void 0 : _b.type) === "LineBasicMaterial");
+};
+exports.REMOVE_EDGES_PREDICATE = REMOVE_EDGES_PREDICATE;
 const REMOVE_VERTEX_PREDICATE = object3D => {
     var _a, _b, _c, _d, _e;
     return object3D.type === "Group" &&
@@ -165,3 +176,10 @@ const REMOVE_VERTEX_PREDICATE = object3D => {
             ((_e = (_d = (_c = object3D.children[0]) === null || _c === void 0 ? void 0 : _c.children[0]) === null || _d === void 0 ? void 0 : _d.geometry) === null || _e === void 0 ? void 0 : _e.type) === "SphereGeometry");
 };
 exports.REMOVE_VERTEX_PREDICATE = REMOVE_VERTEX_PREDICATE;
+const REMOVE_METADATA_PREDICATE = object3D => {
+    var _a, _b, _c;
+    return ((_a = object3D.material) === null || _a === void 0 ? void 0 : _a.type) === "LineDashedMaterial" ||
+        (object3D.type === "Group" &&
+            ((_c = (_b = object3D.children[0]) === null || _b === void 0 ? void 0 : _b.material) === null || _c === void 0 ? void 0 : _c.type) === "LineDashedMaterial");
+};
+exports.REMOVE_METADATA_PREDICATE = REMOVE_METADATA_PREDICATE;

--- a/dist/figures-constants.js
+++ b/dist/figures-constants.js
@@ -1,11 +1,8 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.REMOVE_METADATA_PREDICATE = exports.REMOVE_VERTEX_PREDICATE = exports.REMOVE_EDGES_PREDICATE = exports.VERTEX_CONFIGURATION = exports.MIN_QUALITY_TO_DISCRIMINATE_CIRCLE = exports.LINE_DASHED_MATERIAL = exports.LINE_BASIC_MATERIAL = exports.DODECAHEDRON_VERTICES = exports.ICOSACAHEDRON_VERTICES = exports.OCTAHEDRON_VERTICES = exports.CUBE_VERTICES = exports.TETRAHEDRON_VERTICES = exports.r = exports.t = void 0;
-const three_1 = require("three");
-exports.t = (1 + Math.sqrt(5)) / 2;
-exports.r = 1 / exports.t;
-exports.TETRAHEDRON_VERTICES = [1, 1, 1, -1, -1, 1, -1, 1, -1, 1, -1, -1];
-const CUBE_VERTICES = (x, y, z) => [
+import { Color, LineBasicMaterial, LineDashedMaterial, MeshLambertMaterial } from "three";
+export const t = (1 + Math.sqrt(5)) / 2;
+export const r = 1 / t;
+export const TETRAHEDRON_VERTICES = [1, 1, 1, -1, -1, 1, -1, 1, -1, 1, -1, -1];
+export const CUBE_VERTICES = (x, y, z) => [
     -x,
     -y,
     -z,
@@ -31,49 +28,48 @@ const CUBE_VERTICES = (x, y, z) => [
     y,
     z
 ];
-exports.CUBE_VERTICES = CUBE_VERTICES;
-exports.OCTAHEDRON_VERTICES = [
+export const OCTAHEDRON_VERTICES = [
     1, 0, 0, -1, 0, 0, 0, 1, 0, 0, -1, 0, 0, 0, 1, 0, 0, -1
 ];
-exports.ICOSACAHEDRON_VERTICES = [
+export const ICOSACAHEDRON_VERTICES = [
     -1,
-    exports.t,
+    t,
     0,
     1,
-    exports.t,
+    t,
     0,
     -1,
-    -exports.t,
+    -t,
     0,
     1,
-    -exports.t,
+    -t,
     0,
     0,
     -1,
-    exports.t,
+    t,
     0,
     1,
-    exports.t,
+    t,
     0,
     -1,
-    -exports.t,
+    -t,
     0,
     1,
-    -exports.t,
-    exports.t,
+    -t,
+    t,
     0,
     -1,
-    exports.t,
+    t,
     0,
     1,
-    -exports.t,
+    -t,
     0,
     -1,
-    -exports.t,
+    -t,
     0,
     1
 ];
-exports.DODECAHEDRON_VERTICES = [
+export const DODECAHEDRON_VERTICES = [
     // (±1, ±1, ±1)
     -1,
     -1,
@@ -101,48 +97,48 @@ exports.DODECAHEDRON_VERTICES = [
     1,
     // (0, ±1/φ, ±φ)
     0,
-    -exports.r,
-    -exports.t,
+    -r,
+    -t,
     0,
-    -exports.r,
-    exports.t,
+    -r,
+    t,
     0,
-    exports.r,
-    -exports.t,
+    r,
+    -t,
     0,
-    exports.r,
-    exports.t,
+    r,
+    t,
     // (±1/φ, ±φ, 0)
-    -exports.r,
-    -exports.t,
+    -r,
+    -t,
     0,
-    -exports.r,
-    exports.t,
+    -r,
+    t,
     0,
-    exports.r,
-    -exports.t,
+    r,
+    -t,
     0,
-    exports.r,
-    exports.t,
+    r,
+    t,
     0,
     // (±φ, 0, ±1/φ)
-    -exports.t,
+    -t,
     0,
-    -exports.r,
-    exports.t,
+    -r,
+    t,
     0,
-    -exports.r,
-    -exports.t,
+    -r,
+    -t,
     0,
-    exports.r,
-    exports.t,
+    r,
+    t,
     0,
-    exports.r
+    r
 ];
-exports.LINE_BASIC_MATERIAL = new three_1.LineBasicMaterial({
+export const LINE_BASIC_MATERIAL = new LineBasicMaterial({
     color: 0x000000
 });
-exports.LINE_DASHED_MATERIAL = new three_1.LineDashedMaterial({
+export const LINE_DASHED_MATERIAL = new LineDashedMaterial({
     color: 0x000000,
     linewidth: 1,
     scale: 1,
@@ -152,9 +148,9 @@ exports.LINE_DASHED_MATERIAL = new three_1.LineDashedMaterial({
 // export const MATH_QUALITY = 50;
 // export const MATH_WIREFRAME_B64 =
 //   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAVElEQVRo3u3RAREAMAwCMTr/nlsd3PIKyJGUN0l2t3X9zGt/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADgB0B9B1PXA3yVG5HyAAAAAElFTkSuQmCC";
-exports.MIN_QUALITY_TO_DISCRIMINATE_CIRCLE = 3; // Triangle
-exports.VERTEX_CONFIGURATION = new three_1.MeshLambertMaterial({
-    color: new three_1.Color("black"),
+export const MIN_QUALITY_TO_DISCRIMINATE_CIRCLE = 3; // Triangle
+export const VERTEX_CONFIGURATION = new MeshLambertMaterial({
+    color: new Color("black"),
     opacity: 1,
     transparent: true
 });
@@ -162,24 +158,21 @@ exports.VERTEX_CONFIGURATION = new three_1.MeshLambertMaterial({
 // sucede cuando se usa joinFigIn3D. Para ver si el Group correspondiente es
 // el de las aristas, se chequea el material del primer elemento.
 // De ser ese el caso, se borra todo el Group (ya que solo tiene aristas)
-const REMOVE_EDGES_PREDICATE = object3D => {
+export const REMOVE_EDGES_PREDICATE = object3D => {
     var _a, _b;
     return object3D.type === "LineSegments" ||
         (object3D.type === "Group" &&
             ((_b = (_a = object3D.children[0]) === null || _a === void 0 ? void 0 : _a.material) === null || _b === void 0 ? void 0 : _b.type) === "LineBasicMaterial");
 };
-exports.REMOVE_EDGES_PREDICATE = REMOVE_EDGES_PREDICATE;
-const REMOVE_VERTEX_PREDICATE = object3D => {
+export const REMOVE_VERTEX_PREDICATE = object3D => {
     var _a, _b, _c, _d, _e;
     return object3D.type === "Group" &&
         (((_b = (_a = object3D.children[0]) === null || _a === void 0 ? void 0 : _a.geometry) === null || _b === void 0 ? void 0 : _b.type) === "SphereGeometry" ||
             ((_e = (_d = (_c = object3D.children[0]) === null || _c === void 0 ? void 0 : _c.children[0]) === null || _d === void 0 ? void 0 : _d.geometry) === null || _e === void 0 ? void 0 : _e.type) === "SphereGeometry");
 };
-exports.REMOVE_VERTEX_PREDICATE = REMOVE_VERTEX_PREDICATE;
-const REMOVE_METADATA_PREDICATE = object3D => {
+export const REMOVE_METADATA_PREDICATE = object3D => {
     var _a, _b, _c;
     return ((_a = object3D.material) === null || _a === void 0 ? void 0 : _a.type) === "LineDashedMaterial" ||
         (object3D.type === "Group" &&
             ((_c = (_b = object3D.children[0]) === null || _b === void 0 ? void 0 : _b.material) === null || _c === void 0 ? void 0 : _c.type) === "LineDashedMaterial");
 };
-exports.REMOVE_METADATA_PREDICATE = REMOVE_METADATA_PREDICATE;

--- a/dist/figures.js
+++ b/dist/figures.js
@@ -1,22 +1,22 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.updateVertexVisibility = exports.updateMetaDataVisibility = exports.updateEdgesVisibility = exports.updateQuality = exports.TorusFigure = exports.TetrahedronFigure = exports.SphereFigure = exports.OctahedronFigure = exports.LineFigure = exports.JoinFigIn3DFigure = exports.IcosahedronFigure = exports.DodecahedronFigure = exports.CylinderFigure = exports.createFigureVertex = exports.createFigureMetaData = exports.createFigureEdges = exports.CubeFigure = exports.figureGeometryDictionary = void 0;
-const THREE = require("three");
+import * as THREE from "three";
 // import { Face3 } from "../node_modules/three/examples/jsm/deprecated/Geometry";
 // import { ParametricGeometry } from "../node_modules/three/examples/jsm/geometries/ParametricGeometry";
-const three_1 = require("three");
+import { Group, Mesh } from "three";
 // Constants
-const figures_constants_1 = require("./figures-constants");
-const joinFigIn3D_1 = require("./joinFigIn3D");
-const utils_1 = require("./utils");
+import { CUBE_VERTICES, DODECAHEDRON_VERTICES, ICOSACAHEDRON_VERTICES, LINE_BASIC_MATERIAL, 
+// MATH_QUALITY,
+// MATH_WIREFRAME_B64,
+MIN_QUALITY_TO_DISCRIMINATE_CIRCLE, OCTAHEDRON_VERTICES, TETRAHEDRON_VERTICES } from "./figures-constants";
+import { joinPolygonsIn3DFigure, joinPolygonsIn3DFigureEdges, joinPolygonsIn3DFigureMetaData, joinPolygonsIn3DFigureVertex } from "./joinFigIn3D";
+import { applyRadius, createDashedLine, createEdgesForAGeometry, createVertex, degreesToRadian, discriminateCircle, getFigureConfiguration, parseRectToPolygon2DPoints } from "./utils";
 // - - - - - - - - - - - - - Constantes - - - - - - - - - - - - -
 const joinFigIn3DCircleFigureJSON = (figure, circlesHaveNotTheSameCenter) => {
     if (circlesHaveNotTheSameCenter) {
-        const quality = Math.max(configuration.quality, figures_constants_1.MIN_QUALITY_TO_DISCRIMINATE_CIRCLE);
+        const quality = Math.max(configuration.quality, MIN_QUALITY_TO_DISCRIMINATE_CIRCLE);
         const customFigure = Object.assign({}, figure);
         const { f1, f2 } = customFigure;
-        f1.pts = (0, utils_1.discriminateCircle)(f1.r, quality, { x: f1.x, y: f1.y });
-        f2.pts = (0, utils_1.discriminateCircle)(f2.r, quality, { x: f2.x, y: f2.y });
+        f1.pts = discriminateCircle(f1.r, quality, { x: f1.x, y: f1.y });
+        f2.pts = discriminateCircle(f2.r, quality, { x: f2.x, y: f2.y });
         return customFigure;
     }
     const customFigure = {
@@ -39,8 +39,8 @@ const joinFigIn3DCircleFigureJSON = (figure, circlesHaveNotTheSameCenter) => {
 const joinFigIn3DRectFigureJSON = (figure) => {
     const customFigure = Object.assign({}, figure);
     const { f1, f2 } = customFigure;
-    f1.pts = (0, utils_1.parseRectToPolygon2DPoints)(f1.w, f1.h, f1.x, f1.y);
-    f2.pts = (0, utils_1.parseRectToPolygon2DPoints)(f2.w, f2.h, f2.x, f2.y);
+    f1.pts = parseRectToPolygon2DPoints(f1.w, f1.h, f1.x, f1.y);
+    f2.pts = parseRectToPolygon2DPoints(f2.w, f2.h, f2.x, f2.y);
     return customFigure;
 };
 const joinFigIn3DFigureDictionary = {
@@ -49,15 +49,15 @@ const joinFigIn3DFigureDictionary = {
         // Se procede a graficar un cilindro oblicuo
         if (circlesHaveNotTheSameCenter) {
             const customFigure = joinFigIn3DCircleFigureJSON(figure, true);
-            return (0, joinFigIn3D_1.joinPolygonsIn3DFigure)(customFigure, configuration.edgesVisibility, false, configuration.metaDataVisibility, configuration.quality, false);
+            return joinPolygonsIn3DFigure(customFigure, configuration.edgesVisibility, false, configuration.metaDataVisibility, configuration.quality, false);
         }
         const customFigure = joinFigIn3DCircleFigureJSON(figure, false);
         return CylinderFigure(customFigure);
     },
-    poly: (figure) => (0, joinFigIn3D_1.joinPolygonsIn3DFigure)(figure, configuration.edgesVisibility, configuration.vertexVisibility, false, configuration.quality, true),
+    poly: (figure) => joinPolygonsIn3DFigure(figure, configuration.edgesVisibility, configuration.vertexVisibility, false, configuration.quality, true),
     rect: (figure) => {
         const customFigure = joinFigIn3DRectFigureJSON(figure);
-        return (0, joinFigIn3D_1.joinPolygonsIn3DFigure)(customFigure, configuration.edgesVisibility, configuration.vertexVisibility, false, configuration.quality, true);
+        return joinPolygonsIn3DFigure(customFigure, configuration.edgesVisibility, configuration.vertexVisibility, false, configuration.quality, true);
     }
 };
 const joinFigIn3DFigureEdgesDictionary = {
@@ -66,15 +66,15 @@ const joinFigIn3DFigureEdgesDictionary = {
         // Se procede a graficar un cilindro oblicuo
         if (circlesHaveNotTheSameCenter) {
             const customFigure = joinFigIn3DCircleFigureJSON(figure, true);
-            return (0, joinFigIn3D_1.joinPolygonsIn3DFigureEdges)(customFigure, false);
+            return joinPolygonsIn3DFigureEdges(customFigure, false);
         }
         const customFigure = joinFigIn3DCircleFigureJSON(figure, false);
-        return createFigureEdges(customFigure, exports.figureGeometryDictionary["cylinder"](figure));
+        return createFigureEdges(customFigure, figureGeometryDictionary["cylinder"](figure));
     },
-    poly: (figure) => (0, joinFigIn3D_1.joinPolygonsIn3DFigureEdges)(figure),
+    poly: (figure) => joinPolygonsIn3DFigureEdges(figure),
     rect: (figure) => {
         const customFigure = joinFigIn3DRectFigureJSON(figure);
-        return (0, joinFigIn3D_1.joinPolygonsIn3DFigureEdges)(customFigure);
+        return joinPolygonsIn3DFigureEdges(customFigure);
     }
 };
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -85,7 +85,7 @@ const joinFigIn3DFigureEdgesDictionary = {
 //     texture.repeat.set(40, 40);
 //   }
 // );
-exports.figureGeometryDictionary = {
+export const figureGeometryDictionary = {
     cube: (figure) => new THREE.BoxGeometry(figure.w, figure.h, figure.l),
     cylinder: (figure) => new THREE.CylinderGeometry(figure.r0, figure.r1, figure.h, configuration.quality),
     dodecahedron: (figure) => new THREE.DodecahedronGeometry(figure.r, 0),
@@ -102,15 +102,15 @@ exports.figureGeometryDictionary = {
 const figureVertexDictionary = {
     cube: (figure) => {
         const { w, h, l } = figure;
-        return (0, utils_1.createVertex)((0, figures_constants_1.CUBE_VERTICES)(w / 2, h / 2, l / 2), configuration.quality);
+        return createVertex(CUBE_VERTICES(w / 2, h / 2, l / 2), configuration.quality);
     },
-    dodecahedron: (figure) => (0, utils_1.createVertex)((0, utils_1.applyRadius)(figure.r, figures_constants_1.DODECAHEDRON_VERTICES), configuration.quality),
-    icosahedron: (figure) => (0, utils_1.createVertex)((0, utils_1.applyRadius)(figure.r, figures_constants_1.ICOSACAHEDRON_VERTICES), configuration.quality),
+    dodecahedron: (figure) => createVertex(applyRadius(figure.r, DODECAHEDRON_VERTICES), configuration.quality),
+    icosahedron: (figure) => createVertex(applyRadius(figure.r, ICOSACAHEDRON_VERTICES), configuration.quality),
     joinFigIn3D: (figure) => figure.f1.kind !== "circle"
-        ? (0, joinFigIn3D_1.joinPolygonsIn3DFigureVertex)(figure, configuration.quality)
+        ? joinPolygonsIn3DFigureVertex(figure, configuration.quality)
         : undefined,
-    octahedron: (figure) => (0, utils_1.createVertex)((0, utils_1.applyRadius)(figure.r, figures_constants_1.OCTAHEDRON_VERTICES), configuration.quality),
-    tetrahedron: (figure) => (0, utils_1.createVertex)((0, utils_1.applyRadius)(figure.r, figures_constants_1.TETRAHEDRON_VERTICES), configuration.quality)
+    octahedron: (figure) => createVertex(applyRadius(figure.r, OCTAHEDRON_VERTICES), configuration.quality),
+    tetrahedron: (figure) => createVertex(applyRadius(figure.r, TETRAHEDRON_VERTICES), configuration.quality)
 };
 /**
  * Configuración del graficador 3D.
@@ -124,19 +124,15 @@ const configuration = {
 const updateEdgesVisibility = (visibility) => {
     configuration.edgesVisibility = visibility;
 };
-exports.updateEdgesVisibility = updateEdgesVisibility;
 const updateMetaDataVisibility = (visibility) => {
     configuration.metaDataVisibility = visibility;
 };
-exports.updateMetaDataVisibility = updateMetaDataVisibility;
 const updateVertexVisibility = (visibility) => {
     configuration.vertexVisibility = visibility;
 };
-exports.updateVertexVisibility = updateVertexVisibility;
 const updateQuality = (quality) => {
     configuration.quality = quality;
 };
-exports.updateQuality = updateQuality;
 /**
  * Dada la geometria de una figura, crea y devuelve su malla de aristas
  * @param figureGeometry La geometria de la figura
@@ -155,7 +151,7 @@ const createFigureEdges = (figure, figureGeometry) => {
         }
         const halfHeight = figure.h / 2;
         // Agrega dos circunferencias para las tapas del cilindro
-        const circleGroup = new three_1.Group();
+        const circleGroup = new Group();
         if (figure.r0 !== 0) {
             const topCircle = createCircle(figure.r0, halfHeight);
             circleGroup.add(topCircle);
@@ -170,24 +166,23 @@ const createFigureEdges = (figure, figureGeometry) => {
         return joinFigIn3DFigureEdgesDictionary[figure.f1.kind](figure);
     }
     // El resto de las figuras
-    return (0, utils_1.createEdgesForAGeometry)(figureGeometry);
+    return createEdgesForAGeometry(figureGeometry);
 };
-exports.createFigureEdges = createFigureEdges;
 const createFigureMetaData = (figure) => {
     // Cilindro
     if (figure.kind === "cylinder") {
-        const metaDataGroup = new three_1.Group();
+        const metaDataGroup = new Group();
         const halfHeight = figure.h / 2;
         /**
          * Linea punteada para la altura del cilindro
          */
-        const heightLine = (0, utils_1.createDashedLine)([
+        const heightLine = createDashedLine([
             { x: 0, y: -halfHeight, z: 0 },
             { x: 0, y: halfHeight, z: 0 }
         ]);
         metaDataGroup.add(heightLine);
         if (figure.r1) {
-            const bottomLine = (0, utils_1.createDashedLine)([
+            const bottomLine = createDashedLine([
                 { x: 0, y: -halfHeight, z: 0 },
                 { x: figure.r1, y: -halfHeight, z: 0 }
             ]);
@@ -195,7 +190,7 @@ const createFigureMetaData = (figure) => {
         }
         // Si los radios no son iguales, se agrega la linea punteada para el radio top
         if (figure.r0 !== figure.r1) {
-            const topLine = (0, utils_1.createDashedLine)([
+            const topLine = createDashedLine([
                 { x: 0, y: halfHeight, z: 0 },
                 { x: figure.r0, y: halfHeight, z: 0 }
             ]);
@@ -206,7 +201,7 @@ const createFigureMetaData = (figure) => {
     // Sphere
     if (figure.kind === "sphere") {
         // Agrega una linea punteada para el radio
-        return (0, utils_1.createDashedLine)([
+        return createDashedLine([
             { x: 0, y: 0, z: 0 },
             { x: 0 + figure.r, y: 0, z: 0 }
         ]);
@@ -222,16 +217,14 @@ const createFigureMetaData = (figure) => {
             return createFigureMetaData(customFigure);
         }
         // Cilindro obliquo
-        return (0, joinFigIn3D_1.joinPolygonsIn3DFigureMetaData)(figure);
+        return joinPolygonsIn3DFigureMetaData(figure);
     }
     return undefined;
 };
-exports.createFigureMetaData = createFigureMetaData;
 const createFigureVertex = (figure) => {
     const figureVertexFunction = figureVertexDictionary[figure.kind];
     return figureVertexFunction ? figureVertexFunction(figure) : undefined;
 };
-exports.createFigureVertex = createFigureVertex;
 /**
  * Dada una geometría, crea una figura teniendo en cuenta la configuración
  * actual del graficador 3D. Es decir, si en el graficador 3D están visibles
@@ -240,7 +233,7 @@ exports.createFigureVertex = createFigureVertex;
  */
 const createFigure = (figureGeometry, figureJSON) => {
     const result = {
-        figure: new three_1.Mesh(figureGeometry, (0, utils_1.getFigureConfiguration)(figureJSON))
+        figure: new Mesh(figureGeometry, getFigureConfiguration(figureJSON))
     };
     if (configuration.edgesVisibility) {
         result["edges"] = createFigureEdges(figureJSON, figureGeometry);
@@ -259,14 +252,13 @@ const createFigure = (figureGeometry, figureJSON) => {
 const createCircle = (radius, centerZ) => {
     const circleGeometry = new THREE.CircleGeometry(radius, 128);
     const edgesGeometry = new THREE.EdgesGeometry(circleGeometry);
-    const circleMesh = new THREE.LineSegments(edgesGeometry, figures_constants_1.LINE_BASIC_MATERIAL);
+    const circleMesh = new THREE.LineSegments(edgesGeometry, LINE_BASIC_MATERIAL);
     // Posicionar correctamente al circulo
     circleMesh.position.set(0, centerZ, 0);
-    circleMesh.rotation.set((0, utils_1.degreesToRadian)(-90), 0, 0);
+    circleMesh.rotation.set(degreesToRadian(-90), 0, 0);
     return circleMesh;
 };
-const CubeFigure = (figure) => createFigure(exports.figureGeometryDictionary["cube"](figure), figure);
-exports.CubeFigure = CubeFigure;
+const CubeFigure = (figure) => createFigure(figureGeometryDictionary["cube"](figure), figure);
 /**
  * Crea un objeto 3D esfera. Adicionalmente, también se puede crear la meta
  * información (linea de radio punteada) asociada a ese objeto.
@@ -274,28 +266,20 @@ exports.CubeFigure = CubeFigure;
  * @param shouldDrawFigure Determina si se quiere dibujar la figura 3D. Útil para cuando solo se quiere dibujar la meta información de la figura
  * @returns Un objeto que contiene el la instancia de la esfera creada, así como la instancia de la meta información de la misma
  */
-const SphereFigure = (figure) => createFigure(exports.figureGeometryDictionary["sphere"](figure), figure);
-exports.SphereFigure = SphereFigure;
+const SphereFigure = (figure) => createFigure(figureGeometryDictionary["sphere"](figure), figure);
 /**
  * Crea un objeto 3D cilindro. Adicionalmente, también se puede crear la meta
  * información (linea de radio punteada) asociada a ese objeto.
  * @param figure JSON de la figura 3D
  * @returns Un objeto que contiene el la instancia del cilindro creado, así como la instancia de la meta información del mismo
  */
-const CylinderFigure = (figure) => createFigure(exports.figureGeometryDictionary["cylinder"](figure), figure);
-exports.CylinderFigure = CylinderFigure;
-const TorusFigure = (figure) => createFigure(exports.figureGeometryDictionary["ring"](figure), figure);
-exports.TorusFigure = TorusFigure;
-const DodecahedronFigure = (figure) => createFigure(exports.figureGeometryDictionary["dodecahedron"](figure), figure);
-exports.DodecahedronFigure = DodecahedronFigure;
-const IcosahedronFigure = (figure) => createFigure(exports.figureGeometryDictionary["icosahedron"](figure), figure);
-exports.IcosahedronFigure = IcosahedronFigure;
+const CylinderFigure = (figure) => createFigure(figureGeometryDictionary["cylinder"](figure), figure);
+const TorusFigure = (figure) => createFigure(figureGeometryDictionary["ring"](figure), figure);
+const DodecahedronFigure = (figure) => createFigure(figureGeometryDictionary["dodecahedron"](figure), figure);
+const IcosahedronFigure = (figure) => createFigure(figureGeometryDictionary["icosahedron"](figure), figure);
 const JoinFigIn3DFigure = (figure) => joinFigIn3DFigureDictionary[figure.f1.kind](figure);
-exports.JoinFigIn3DFigure = JoinFigIn3DFigure;
-const TetrahedronFigure = (figure) => createFigure(exports.figureGeometryDictionary["tetrahedron"](figure), figure);
-exports.TetrahedronFigure = TetrahedronFigure;
-const OctahedronFigure = (figure) => createFigure(exports.figureGeometryDictionary["octahedron"](figure), figure);
-exports.OctahedronFigure = OctahedronFigure;
+const TetrahedronFigure = (figure) => createFigure(figureGeometryDictionary["tetrahedron"](figure), figure);
+const OctahedronFigure = (figure) => createFigure(figureGeometryDictionary["octahedron"](figure), figure);
 function LineFigure(figure) {
     const pointsLine = [];
     pointsLine.push(new THREE.Vector3(figure.pts[0][1], figure.pts[0][2], figure.pts[0][0]));
@@ -310,4 +294,94 @@ function LineFigure(figure) {
         figure: figureMesh
     };
 }
-exports.LineFigure = LineFigure;
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// No se recomienda usar más Geometry, ya que fue deprecado. Lo mejor es usar
+// BufferGeometry que además rinde mejor. Acá se hace un WA para en la versión
+// más reciente de ThreeJS seguir usando Geometry sin romper el código legado
+// https://stackoverflow.com/questions/67767491/why-i-cant-create-face3-in-threejs-typescript-project
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// function getMathMesh(geometry) {
+//   const wireMaterial = new MeshBasicMaterial({
+//     map: wireTexture,
+//     vertexColors: true,
+//     side: THREE.DoubleSide
+//   });
+//   geometry.computeBoundingBox();
+//   const yMin = geometry.boundingBox.min.y;
+//   const yMax = geometry.boundingBox.max.y;
+//   const yRange = yMax - yMin;
+//   let color, point, face, numberOfSides, vertexIndex;
+//   // faces are indexed using characters
+//   const faceIndices = ["a", "b", "c", "d"];
+//   // first, assign colors to vertices as desired
+//   for (let i = 0; i < geometry.vertices.length; i++) {
+//     point = geometry.vertices[i];
+//     color = new THREE.Color(0xffffff);
+//     color.setHSL((0.7 * (yMax - point.y)) / yRange, 1, 0.5);
+//     geometry.colors[i] = color; // use this array for convenience
+//   }
+//   // copy the colors as necessary to the face's vertexColors array.
+//   for (let i = 0; i < geometry.faces.length; i++) {
+//     face = geometry.faces[i];
+//     numberOfSides = face instanceof Face3 ? 3 : 4;
+//     for (let j = 0; j < numberOfSides; j++) {
+//       vertexIndex = face[faceIndices[j]];
+//       face.vertexColors[j] = geometry.colors[vertexIndex];
+//     }
+//   }
+//   // @todo ¿Sacar el signo de pregunta y resolver el error?
+//   wireMaterial.map?.repeat.set(MATH_QUALITY, MATH_QUALITY);
+//   return new THREE.Mesh(geometry, wireMaterial);
+// }
+// function MathFunctionFigure(axes, figure) {
+//   const xRange = axes.x.max - axes.x.min;
+//   const yRange = axes.y.max - axes.y.min;
+//   const zFunc = figure.fn;
+//   const meshFunction = function (x, y) {
+//     x = xRange * x + axes.x.min;
+//     y = yRange * y + axes.y.min;
+//     const z = zFunc(x, y);
+//     if (isNaN(z)) {
+//       return new THREE.Vector3(0, 0, 0);
+//     } // TODO: better fix
+//     else {
+//       return new THREE.Vector3(x, z, y);
+//     }
+//   };
+//   const graphGeometry = new ParametricGeometry(
+//     meshFunction,
+//     MATH_QUALITY,
+//     MATH_QUALITY
+//   );
+//   const mesh = getMathMesh(graphGeometry);
+//   return mesh;
+// }
+// function MathParametricFigure(_axes, figure) {
+//   const uRange = figure.u1 - figure.u0;
+//   const vRange = figure.v1 - figure.v0;
+//   const meshFunction = function (u, v) {
+//     const _u = uRange * u + figure.u0;
+//     const _v = vRange * v + figure.v0;
+//     const x = figure.fn.x(_u, _v);
+//     const y = figure.fn.y(_u, _v);
+//     const z = figure.fn.z(_u, _v);
+//     if (isNaN(x) || isNaN(y) || isNaN(z)) {
+//       return new THREE.Vector3(0, 0, 0);
+//     } // TODO: better fix
+//     else {
+//       return new THREE.Vector3(x, z, y);
+//     }
+//   };
+//   const graphGeometry = new ParametricGeometry(
+//     meshFunction,
+//     MATH_QUALITY,
+//     MATH_QUALITY
+//   );
+//   graphGeometry.computeBoundingBox();
+//   const mesh = getMathMesh(graphGeometry);
+//   return mesh;
+// }
+export { CubeFigure, createFigureEdges, createFigureMetaData, createFigureVertex, CylinderFigure, DodecahedronFigure, IcosahedronFigure, JoinFigIn3DFigure, LineFigure, 
+// MathFunctionFigure,
+// MathParametricFigure,
+OctahedronFigure, SphereFigure, TetrahedronFigure, TorusFigure, updateQuality, updateEdgesVisibility, updateMetaDataVisibility, updateVertexVisibility };

--- a/dist/graph3d-utils.js
+++ b/dist/graph3d-utils.js
@@ -1,8 +1,5 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.createFigure3DVertex = exports.createFigure3DMetaData = exports.createFigure3DEdges = exports.createFigure3D = exports.getFigureKey = void 0;
-const Figures = require("./figures");
-const figures_1 = require("./figures");
+import * as Figures from "./figures";
+import { createFigureEdges, createFigureMetaData, createFigureVertex, figureGeometryDictionary } from "./figures";
 // Helpers
 const figureKeyDictionary = {
     // Se usa para obtener un identificador de la figura 2D
@@ -43,8 +40,7 @@ const figureKeyDictionary = {
  * | `"md"`  | MetaData    |
  * | `"vtx"` | Vertex      |
  */
-const getFigureKey = (figure, type) => `${type}-${figureKeyDictionary[figure.kind](figure)}`;
-exports.getFigureKey = getFigureKey;
+export const getFigureKey = (figure, type) => `${type}-${figureKeyDictionary[figure.kind](figure)}`;
 /**
  * Dictionario de funciones. Sirve para mapear nombre de funciones a renders de
  * las mismas.
@@ -68,13 +64,9 @@ const figureDictionary = {
  * @param figure JSON de la figura que se quiere dibujar
  * @returns El render de la figura `figure`
  */
-const createFigure3D = (figure) => figureDictionary[figure.kind](figure);
-exports.createFigure3D = createFigure3D;
-const createFigure3DEdges = (figure) => figure.kind === "cylinder" || figure.kind === "joinFigIn3D"
-    ? (0, figures_1.createFigureEdges)(figure)
-    : (0, figures_1.createFigureEdges)(figure, figures_1.figureGeometryDictionary[figure.kind](figure));
-exports.createFigure3DEdges = createFigure3DEdges;
-const createFigure3DMetaData = (figure) => (0, figures_1.createFigureMetaData)(figure);
-exports.createFigure3DMetaData = createFigure3DMetaData;
-const createFigure3DVertex = (figure) => (0, figures_1.createFigureVertex)(figure);
-exports.createFigure3DVertex = createFigure3DVertex;
+export const createFigure3D = (figure) => figureDictionary[figure.kind](figure);
+export const createFigure3DEdges = (figure) => figure.kind === "cylinder" || figure.kind === "joinFigIn3D"
+    ? createFigureEdges(figure)
+    : createFigureEdges(figure, figureGeometryDictionary[figure.kind](figure));
+export const createFigure3DMetaData = (figure) => createFigureMetaData(figure);
+export const createFigure3DVertex = (figure) => createFigureVertex(figure);

--- a/dist/graph3d.js
+++ b/dist/graph3d.js
@@ -242,19 +242,8 @@ function showEdges(visible) {
         showEdgesForEachRenderedFigure();
     }
     else {
-        // Se puede dar el caso en que se está renderizando una figura agrupada,
-        // esto sucede cuando se usa joinFigIn3D. Para ver si el Group
-        // correspondiente es el de las aristas, se chequea el primer elemento.
-        // De ser ese el caso, se borra todo el Group (ya que solo tiene aristas)
-        const predicateToRemove = object3D => {
-            var _a, _b;
-            return object3D.type === "LineSegments" ||
-                (object3D.type === "Group" &&
-                    (((_a = object3D.children[0]) === null || _a === void 0 ? void 0 : _a.type) === "LineSegments" ||
-                        ((_b = object3D.children[0]) === null || _b === void 0 ? void 0 : _b.type) === "Line"));
-        };
         /** Arreglo de objetos 3D que representan las aristas renderizadas */
-        const childrensToRemove = _group.children.filter(predicateToRemove);
+        const childrensToRemove = _group.children.filter(figures_constants_1.REMOVE_EDGES_PREDICATE);
         /* Si el anterior chequeo da problemas, se puede probar con la condición de filtrado:
             object3D instanceof
             THREE.LineSegments<
@@ -332,9 +321,6 @@ function showVertexForEachRenderedFigure() {
         if (figureVertex) {
             configureFigureInformationAndAddToTheScene(figure, figureVertex);
         }
-        // joinFigIn3D
-        // else if (figure.kind == "joinFigIn3D" && figure.f1.kind == "circle") {
-        //   figureRender = Figures.JoinFigIn3DFigure(figure, false);
     });
 }
 /**
@@ -359,13 +345,7 @@ function showMetaData(visible) {
         // El casteo a any[] se realiza porque TypeScript dice que los objetos 3D no
         // tiene material, pero depurando (haciendo console.log) se ve que algunos si tienen
         /** Arreglo de objetos 3D que representan la meta información renderizada */
-        const childrensToRemove = _group.children.filter(object3D => {
-            var _a;
-            return (object3D.material &&
-                object3D.material.type === "LineDashedMaterial") ||
-                (object3D.type === "Group" &&
-                    ((_a = object3D.children[0]) === null || _a === void 0 ? void 0 : _a.material.type) === "LineDashedMaterial");
-        });
+        const childrensToRemove = _group.children.filter(figures_constants_1.REMOVE_METADATA_PREDICATE);
         _group.remove(...childrensToRemove);
     }
     // Actualizar la escena
@@ -389,9 +369,6 @@ function showMetaDataForEachRenderedFigure() {
         if (figureMetaData) {
             configureFigureInformationAndAddToTheScene(figure, figureMetaData);
         }
-        // joinFigIn3D
-        // else if (figure.kind == "joinFigIn3D" && figure.f1.kind == "circle") {
-        //   figureRender = Figures.JoinFigIn3DFigure(figure, false);
     });
 }
 function changeSize(size) {

--- a/dist/graph3d.js
+++ b/dist/graph3d.js
@@ -1,15 +1,12 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.reset = exports.changeOptions = exports.changeZoom = exports.changeZoomType = exports.changeSize = exports.showMetaData = exports.showVertices = exports.showEdges = exports.showAxes = exports.changeAxesSize = exports.clearSceneObjects = exports.changeSpeedAnimation = exports.pauseAnimation = exports.playAnimation = exports.initializeAnimation = exports.drawFigures = exports.initialize = void 0;
-const Figures = require("./figures");
+import * as Figures from "./figures";
 const THREE = require("three");
-const axes_1 = require("./axes");
-const memory_cache_1 = require("./memory_cache");
-const orbit_controls_1 = require("./orbit_controls");
-const three_1 = require("three");
-const utils_1 = require("./utils");
-const graph3d_utils_1 = require("./graph3d-utils");
-const figures_constants_1 = require("./figures-constants");
+import Axes from "./axes";
+import MemoryCache from "./memory_cache";
+import OrbitControls from "./orbit_controls";
+import { Scene } from "three";
+import { degreesToRadian } from "./utils";
+import { createFigure3DEdges, createFigure3D, createFigure3DMetaData, getFigureKey, createFigure3DVertex } from "./graph3d-utils";
+import { REMOVE_EDGES_PREDICATE, REMOVE_METADATA_PREDICATE, REMOVE_VERTEX_PREDICATE } from "./figures-constants";
 // import { MathFunctionFigure, MathParametricFigure } from "./figures";
 const DEFAULT_AXES_WIDTH = { min: -10, max: 10 };
 const ZOOM_SPEED = 0.025;
@@ -67,10 +64,10 @@ let _initialized = false;
 /**
  * @param  {string} domElem dom node name, where canvas will put it
  */
-function initialize(domElem) {
+export function initialize(domElem) {
     const width = domElem.getBoundingClientRect().width || 50;
     const height = domElem.getBoundingClientRect().height || 50;
-    _scene = new three_1.Scene();
+    _scene = new Scene();
     _camera = new THREE.PerspectiveCamera(50, width / height, 0.1, 1000);
     _renderer = new THREE.WebGLRenderer({ antialias: true });
     _renderer.setSize(width, height);
@@ -82,13 +79,13 @@ function initialize(domElem) {
     _scene.add(_camera);
     _camera.add(_light);
     _camera.position.set(5, 5, 25);
-    _controls = new orbit_controls_1.default(_camera, _renderer.domElement);
+    _controls = new OrbitControls(_camera, _renderer.domElement);
     _controls.addEventListener("change", function () {
         // _light.position.copy(_camera.getWorldPosition());
         _renderer.render(_scene, _camera);
     });
     _renderer.domElement.addEventListener("wheel", onMouseWheel, false);
-    _axes = new axes_1.default();
+    _axes = new Axes();
     _axes.setScale({
         xMin: DEFAULT_AXES_WIDTH.min,
         xMax: DEFAULT_AXES_WIDTH.max,
@@ -104,21 +101,19 @@ function initialize(domElem) {
     _renderer.render(_scene, _camera);
     _initialized = true;
 }
-exports.initialize = initialize;
 /**
  * @param figures Un array de las figuras 3D, representadas como JSONs
  */
-function drawFigures(figures) {
+export function drawFigures(figures) {
     clearSceneObjects();
     figures.forEach(function (figure) {
-        const figureRender = (0, graph3d_utils_1.createFigure3D)(figure);
+        const figureRender = createFigure3D(figure);
         setFigurePropertiesAndAddToScene(figure, figureRender);
     });
     _props.requireUpdate = false;
     _props.data = figures;
     _renderer.render(_scene, _camera);
 }
-exports.drawFigures = drawFigures;
 function setFigurePropertiesAndAddToScene(figure, figureRender) {
     configureFigureAndAddToGroup(figure, figureRender.figure);
     if (configuration.edgesVisibility && figureRender.edges) {
@@ -150,38 +145,34 @@ function configureFigureAndAddToGroup(figure, figureMesh) {
  * @param data Arreglo de figuras
  * @param {function} cbProgress callback function, will be called for notification progress change
  */
-function initializeAnimation(data, cbProgress) {
+export function initializeAnimation(data, cbProgress) {
     _props.dataAnimation = data;
     _props.requireUpdate = false;
     _animation.key = 0;
     _animation.callbackProgress = cbProgress;
-    _cache = new memory_cache_1.default(750, 50 * 1000);
+    _cache = new MemoryCache(750, 50 * 1000);
 }
-exports.initializeAnimation = initializeAnimation;
-function playAnimation() {
+export function playAnimation() {
     if (_initialized) {
         _animation.running = true;
         animate();
     }
 }
-exports.playAnimation = playAnimation;
-function pauseAnimation() {
+export function pauseAnimation() {
     if (_initialized) {
         _animation.running = false;
         clearTimeout(_animation.timeoutRef);
     }
 }
-exports.pauseAnimation = pauseAnimation;
 /**
  * Cambia la frecuencia con la cual se actualizan las figuras en la animación
  * de este estilo `[esfera(3), esfera(5), anillo(3, 5, 1)]`
  * @param delay Retraso con el cual se cambia entre figuras de una animación
  */
-function changeSpeedAnimation(delay) {
+export function changeSpeedAnimation(delay) {
     _animation.delay = delay;
 }
-exports.changeSpeedAnimation = changeSpeedAnimation;
-function clearSceneObjects(stopAnimation = true) {
+export function clearSceneObjects(stopAnimation = true) {
     if (stopAnimation) {
         clearTimeout(_animation.timeoutRef);
         // Se reinicia el arreglo de animaciones, ya que no se están renderizando animaciones
@@ -192,7 +183,6 @@ function clearSceneObjects(stopAnimation = true) {
     _props.data = [];
     _renderer.render(_scene, _camera);
 }
-exports.clearSceneObjects = clearSceneObjects;
 // export function drawMath(isParametric, figure) {
 //   _props.requireUpdate = true;
 //   _props.data = figure;
@@ -206,7 +196,7 @@ exports.clearSceneObjects = clearSceneObjects;
 //   };
 //   _props.updateCallback();
 // }
-function changeAxesSize(axes) {
+export function changeAxesSize(axes) {
     if (_initialized) {
         _axes.setScale(axes);
         if (_props.requireUpdate) {
@@ -215,21 +205,19 @@ function changeAxesSize(axes) {
         _renderer.render(_scene, _camera);
     }
 }
-exports.changeAxesSize = changeAxesSize;
-function showAxes(visible) {
+export function showAxes(visible) {
     if (_initialized) {
         _axes.group.visible = visible;
         _renderer.render(_scene, _camera);
     }
 }
-exports.showAxes = showAxes;
 /**
  * Muestra o oculta las aristras de las figuras actualmente renderizadas.
  * @param visible Determina si los aristas serán visibles o ocultadas.
  *
  * @todo TODO: Completar la implementación
  */
-function showEdges(visible) {
+export function showEdges(visible) {
     // Si no se ha inicializado, no se hace nada
     if (!_initialized) {
         return;
@@ -243,7 +231,7 @@ function showEdges(visible) {
     }
     else {
         /** Arreglo de objetos 3D que representan las aristas renderizadas */
-        const childrensToRemove = _group.children.filter(figures_constants_1.REMOVE_EDGES_PREDICATE);
+        const childrensToRemove = _group.children.filter(REMOVE_EDGES_PREDICATE);
         /* Si el anterior chequeo da problemas, se puede probar con la condición de filtrado:
             object3D instanceof
             THREE.LineSegments<
@@ -256,7 +244,6 @@ function showEdges(visible) {
     // Actualizar la escena
     _renderer.render(_scene, _camera);
 }
-exports.showEdges = showEdges;
 /**
  * Dependiendo de si se está renderizando una secuencia de figuras 3D o solo
  * una figura 3D, muestra las aristas de las figuras actualmente renderizadas.
@@ -270,7 +257,7 @@ function showEdgesForEachRenderedFigure() {
     }
     // Las figuras no son de una secuencia
     _props.data.forEach(figure => {
-        const figureEdges = (0, graph3d_utils_1.createFigure3DEdges)(figure);
+        const figureEdges = createFigure3DEdges(figure);
         if (figureEdges) {
             configureFigureInformationAndAddToTheScene(figure, figureEdges);
         }
@@ -282,7 +269,7 @@ function showEdgesForEachRenderedFigure() {
  *
  * @todo TODO: Completar la implementación
  */
-function showVertices(visible) {
+export function showVertices(visible) {
     // Si no se ha inicializado, no se hace nada
     if (!_initialized) {
         return;
@@ -298,13 +285,12 @@ function showVertices(visible) {
         // El casteo a any[] se realiza porque TypeScript dice que los objetos 3D no
         // tiene material, pero depurando (haciendo console.log) se ve que algunos si tienen
         /** Arreglo de objetos 3D que representan los vértices renderizados */
-        const childrensToRemove = _group.children.filter(figures_constants_1.REMOVE_VERTEX_PREDICATE);
+        const childrensToRemove = _group.children.filter(REMOVE_VERTEX_PREDICATE);
         _group.remove(...childrensToRemove);
     }
     // Actualizar la escena
     _renderer.render(_scene, _camera);
 }
-exports.showVertices = showVertices;
 /**
  * Dependiendo de si se está renderizando una secuencia de figuras 3D o solo
  * una figura 3D, muestra los vértices de las figuras actualmente renderizados.
@@ -317,7 +303,7 @@ function showVertexForEachRenderedFigure() {
         return;
     }
     _props.data.forEach(figure => {
-        const figureVertex = (0, graph3d_utils_1.createFigure3DVertex)(figure);
+        const figureVertex = createFigure3DVertex(figure);
         if (figureVertex) {
             configureFigureInformationAndAddToTheScene(figure, figureVertex);
         }
@@ -329,7 +315,7 @@ function showVertexForEachRenderedFigure() {
  *
  * @todo TODO: Completar la implementación
  */
-function showMetaData(visible) {
+export function showMetaData(visible) {
     // Si no se ha inicializado, no se hace nada
     if (!_initialized) {
         return;
@@ -345,13 +331,12 @@ function showMetaData(visible) {
         // El casteo a any[] se realiza porque TypeScript dice que los objetos 3D no
         // tiene material, pero depurando (haciendo console.log) se ve que algunos si tienen
         /** Arreglo de objetos 3D que representan la meta información renderizada */
-        const childrensToRemove = _group.children.filter(figures_constants_1.REMOVE_METADATA_PREDICATE);
+        const childrensToRemove = _group.children.filter(REMOVE_METADATA_PREDICATE);
         _group.remove(...childrensToRemove);
     }
     // Actualizar la escena
     _renderer.render(_scene, _camera);
 }
-exports.showMetaData = showMetaData;
 /**
  * Dependiendo de si se está renderizando una secuencia de figuras 3D o solo
  * una figura 3D, muestra la meta informacion de las figuras actualmente
@@ -365,13 +350,13 @@ function showMetaDataForEachRenderedFigure() {
         return;
     }
     _props.data.forEach(figure => {
-        const figureMetaData = (0, graph3d_utils_1.createFigure3DMetaData)(figure);
+        const figureMetaData = createFigure3DMetaData(figure);
         if (figureMetaData) {
             configureFigureInformationAndAddToTheScene(figure, figureMetaData);
         }
     });
 }
-function changeSize(size) {
+export function changeSize(size) {
     const newAspect = size.width / size.height;
     if (_camera.aspect !== newAspect ||
         _renderer.getSize().width !== size.width ||
@@ -382,8 +367,7 @@ function changeSize(size) {
         _renderer.render(_scene, _camera);
     }
 }
-exports.changeSize = changeSize;
-function changeZoomType(type) {
+export function changeZoomType(type) {
     _props.zoom.type = type;
     if (_props.zoom.type === ZOOM_TYPE.ALL) {
         _controls.enableZoom = true;
@@ -392,8 +376,7 @@ function changeZoomType(type) {
         _controls.enableZoom = false;
     }
 }
-exports.changeZoomType = changeZoomType;
-function changeZoom(increase = true) {
+export function changeZoom(increase = true) {
     if (_initialized) {
         const zoomEvent = new Event("wheel");
         if (increase) {
@@ -405,12 +388,11 @@ function changeZoom(increase = true) {
         _renderer.domElement.dispatchEvent(zoomEvent);
     }
 }
-exports.changeZoom = changeZoom;
 /**
  * Actualiza la configuración de la calidad de las figuras
  * @param options Configuración del graficador 3D
  */
-function changeOptions(options) {
+export function changeOptions(options) {
     for (const property in options) {
         if (configuration.hasOwnProperty(property)) {
             configuration[property] = options[property];
@@ -418,12 +400,11 @@ function changeOptions(options) {
     }
     Figures.updateQuality(configuration.quality);
 }
-exports.changeOptions = changeOptions;
 /**
  * Reinicia el zoom, centrando la cámara en la posición por defecto.
  * Se mapea directamente con la función "Centrar" del Front-End
  */
-function reset() {
+export function reset() {
     _props.zoom.x = 1;
     _props.zoom.y = 1;
     _props.zoom.z = 1;
@@ -435,7 +416,6 @@ function reset() {
     _controls.reset();
     _renderer.render(_scene, _camera);
 }
-exports.reset = reset;
 /**
  * Se utiliza para crear una secuencia de figuras las cuales son cambiadas
  * a intervalos de tiempo. Dichos intervalos de tiempo están determinados
@@ -465,48 +445,48 @@ const animate = () => {
     _renderer.render(_scene, _camera);
 };
 function renderFigureWithCache(figure, type) {
-    const figureKey = (0, graph3d_utils_1.getFigureKey)(figure, type);
+    const figureKey = getFigureKey(figure, type);
     const cachedFigureMesh = _cache.get(figureKey);
     let figureMesh;
     // Si no está cacheada la figura, dibuja la figura y agrega el mapeado a la
     // caché
     if (!cachedFigureMesh) {
         if (type === "fig") {
-            figureMesh = (0, graph3d_utils_1.createFigure3D)(figure);
+            figureMesh = createFigure3D(figure);
             _cache.set(figureKey, figureMesh.figure);
             if (figureMesh.edges) {
-                const edgesKey = (0, graph3d_utils_1.getFigureKey)(figure, "ed");
+                const edgesKey = getFigureKey(figure, "ed");
                 cachedUsed[edgesKey] = true;
                 _cache.set(edgesKey, figureMesh.edges);
             }
             if (figureMesh.metaData) {
-                const metaDataKey = (0, graph3d_utils_1.getFigureKey)(figure, "md");
+                const metaDataKey = getFigureKey(figure, "md");
                 cachedUsed[metaDataKey] = true;
                 _cache.set(metaDataKey, figureMesh.metaData);
             }
             if (figureMesh.vertex) {
-                const vertexKey = (0, graph3d_utils_1.getFigureKey)(figure, "vtx");
+                const vertexKey = getFigureKey(figure, "vtx");
                 cachedUsed[vertexKey] = true;
                 _cache.set(vertexKey, figureMesh.vertex);
             }
         }
         // Edges
         else if (type === "ed") {
-            figureMesh = (0, graph3d_utils_1.createFigure3DEdges)(figure);
+            figureMesh = createFigure3DEdges(figure);
             if (figureMesh) {
                 _cache.set(figureKey, figureMesh);
             }
         }
         // MetaData
         else if (type === "md") {
-            figureMesh = (0, graph3d_utils_1.createFigure3DMetaData)(figure);
+            figureMesh = createFigure3DMetaData(figure);
             if (figureMesh) {
                 _cache.set(figureKey, figureMesh);
             }
         }
         // Vertex
         else {
-            figureMesh = (0, graph3d_utils_1.createFigure3DVertex)(figure);
+            figureMesh = createFigure3DVertex(figure);
             if (figureMesh) {
                 _cache.set(figureKey, figureMesh);
             }
@@ -628,7 +608,7 @@ const setFigureRotation = (figure, mesh) => {
                     figure.f1.y !== figure.f2.y)))
         ? figure.rot.y - 90
         : figure.rot.y;
-    mesh.rotation.set((0, utils_1.degreesToRadian)(yRotation), (0, utils_1.degreesToRadian)(figure.rot.z), (0, utils_1.degreesToRadian)(figure.rot.x));
+    mesh.rotation.set(degreesToRadian(yRotation), degreesToRadian(figure.rot.z), degreesToRadian(figure.rot.x));
 };
 const setFigurePosition = (figure, mesh) => {
     mesh.position.set(figure.y, figure.z, figure.x);

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,25 +1,8 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.reset = exports.changeOptions = exports.showVertices = exports.showMetaData = exports.showEdges = exports.showAxes = exports.changeAxesSize = exports.changeSize = exports.changeZoom = exports.changeZoomType = exports.pauseAnimation = exports.playAnimation = exports.changeSpeedAnimation = exports.initializeAnimation = exports.drawFigures = exports.clearSceneObjects = exports.initialize = void 0;
-var graph3d_1 = require("./graph3d");
-Object.defineProperty(exports, "initialize", { enumerable: true, get: function () { return graph3d_1.initialize; } });
-Object.defineProperty(exports, "clearSceneObjects", { enumerable: true, get: function () { return graph3d_1.clearSceneObjects; } });
+export { initialize, clearSceneObjects, 
 // static figures
-Object.defineProperty(exports, "drawFigures", { enumerable: true, get: function () { return graph3d_1.drawFigures; } });
+drawFigures, 
 // drawMath,
 // animation
-Object.defineProperty(exports, "initializeAnimation", { enumerable: true, get: function () { return graph3d_1.initializeAnimation; } });
-Object.defineProperty(exports, "changeSpeedAnimation", { enumerable: true, get: function () { return graph3d_1.changeSpeedAnimation; } });
-Object.defineProperty(exports, "playAnimation", { enumerable: true, get: function () { return graph3d_1.playAnimation; } });
-Object.defineProperty(exports, "pauseAnimation", { enumerable: true, get: function () { return graph3d_1.pauseAnimation; } });
+initializeAnimation, changeSpeedAnimation, playAnimation, pauseAnimation, 
 // layout
-Object.defineProperty(exports, "changeZoomType", { enumerable: true, get: function () { return graph3d_1.changeZoomType; } });
-Object.defineProperty(exports, "changeZoom", { enumerable: true, get: function () { return graph3d_1.changeZoom; } });
-Object.defineProperty(exports, "changeSize", { enumerable: true, get: function () { return graph3d_1.changeSize; } });
-Object.defineProperty(exports, "changeAxesSize", { enumerable: true, get: function () { return graph3d_1.changeAxesSize; } });
-Object.defineProperty(exports, "showAxes", { enumerable: true, get: function () { return graph3d_1.showAxes; } });
-Object.defineProperty(exports, "showEdges", { enumerable: true, get: function () { return graph3d_1.showEdges; } });
-Object.defineProperty(exports, "showMetaData", { enumerable: true, get: function () { return graph3d_1.showMetaData; } });
-Object.defineProperty(exports, "showVertices", { enumerable: true, get: function () { return graph3d_1.showVertices; } });
-Object.defineProperty(exports, "changeOptions", { enumerable: true, get: function () { return graph3d_1.changeOptions; } });
-Object.defineProperty(exports, "reset", { enumerable: true, get: function () { return graph3d_1.reset; } });
+changeZoomType, changeZoom, changeSize, changeAxesSize, showAxes, showEdges, showMetaData, showVertices, changeOptions, reset } from "./graph3d";

--- a/dist/interfaces.js
+++ b/dist/interfaces.js
@@ -1,2 +1,1 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
+export {};

--- a/dist/memory_cache.js
+++ b/dist/memory_cache.js
@@ -1,5 +1,4 @@
 "use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
 const DEFAULT_SIZE = 50;
 const DEFAULT_EXPIRE_TIME_MS = 10000;
 /**
@@ -85,4 +84,4 @@ MemoryCache.prototype.clear = function () {
     this._freeSpace = this._size;
     this._timeouts = Object.create(null);
 };
-exports.default = MemoryCache;
+export default MemoryCache;

--- a/dist/orbit_controls.js
+++ b/dist/orbit_controls.js
@@ -1,5 +1,3 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
 const THREE = require("three");
 /**
  * @author qiao / https://github.com/qiao
@@ -680,4 +678,4 @@ Object.defineProperties(OrbitControls.prototype, {
         }
     }
 });
-exports.default = OrbitControls;
+export default OrbitControls;

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -1,25 +1,20 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.createDashedLine = exports.createVertex = exports.createEdgesForAGeometry = exports.applyRadius = exports.discriminateCircle = exports.parseRectToPolygon2DPoints = exports.getFigureConfiguration = exports.degreesToRadian = void 0;
-const three_1 = require("three");
-const figures_constants_1 = require("./figures-constants");
-const degreesToRadian = (degrees) => (degrees * Math.PI) / 180;
-exports.degreesToRadian = degreesToRadian;
+import { BufferGeometry, Color, EdgesGeometry, Group, Line, LineSegments, Mesh, MeshLambertMaterial, SphereGeometry, Vector3 } from "three";
+import { LINE_BASIC_MATERIAL, LINE_DASHED_MATERIAL, VERTEX_CONFIGURATION } from "./figures-constants";
+export const degreesToRadian = (degrees) => (degrees * Math.PI) / 180;
 /**
  * Dada una figura, retorna un objeto que corresponde a la configuración de su
  * color.
  * @param figure Una figura de MateFun
  */
-const getFigureConfiguration = (figure) => {
+export const getFigureConfiguration = (figure) => {
     const opacity = 1 - figure.transparency;
     const configuration = {
-        color: new three_1.Color(figure.color),
+        color: new Color(figure.color),
         opacity,
         transparent: true
     };
-    return new three_1.MeshLambertMaterial(configuration);
+    return new MeshLambertMaterial(configuration);
 };
-exports.getFigureConfiguration = getFigureConfiguration;
 /**
  * Dadas las proporciones de un rectángulo y su centro, se devuelve los puntos
  * asociados al plano 2D en que los vértices del rectángulo se encuentran
@@ -29,7 +24,7 @@ exports.getFigureConfiguration = getFigureConfiguration;
  * @param y Centro en y del rectángulo
  * @return Los vértices del rectángulo
  */
-const parseRectToPolygon2DPoints = (width, height, x, y) => {
+export const parseRectToPolygon2DPoints = (width, height, x, y) => {
     const halfWidth = width / 2;
     const halfHeight = height / 2;
     return [
@@ -39,7 +34,6 @@ const parseRectToPolygon2DPoints = (width, height, x, y) => {
         [x - halfWidth, y - halfHeight]
     ];
 };
-exports.parseRectToPolygon2DPoints = parseRectToPolygon2DPoints;
 /**
  * Aproxima un circulo mediante un poligono y una calidad de aproximación. A
  * mayor calidad, mejor es la aproximación.
@@ -48,8 +42,8 @@ exports.parseRectToPolygon2DPoints = parseRectToPolygon2DPoints;
  * @param center El centro del circulo. Necesario para posicionar correctamente los puntos de la aproximación
  * @returns Poligono interior al circulo, el cual es una aproximación de este
  */
-const discriminateCircle = (radius, quality, center) => {
-    const incrementStep = (0, exports.degreesToRadian)(360 / quality);
+export const discriminateCircle = (radius, quality, center) => {
+    const incrementStep = degreesToRadian(360 / quality);
     let iterationAngle = 0;
     const discriminatedCircle = [];
     const { x, y } = center;
@@ -61,9 +55,8 @@ const discriminateCircle = (radius, quality, center) => {
     }
     return discriminatedCircle;
 };
-exports.discriminateCircle = discriminateCircle;
-const applyRadius = (radius, vertices) => {
-    const vertex = new three_1.Vector3();
+export const applyRadius = (radius, vertices) => {
+    const vertex = new Vector3();
     const normalizedVertices = [];
     // Se itera sobre todos los vertices y se le aplica el radio a cada uno
     for (let i = 0; i < vertices.length; i += 3) {
@@ -77,9 +70,7 @@ const applyRadius = (radius, vertices) => {
     }
     return normalizedVertices;
 };
-exports.applyRadius = applyRadius;
-const createEdgesForAGeometry = (figureGeometry) => new three_1.LineSegments(new three_1.EdgesGeometry(figureGeometry), figures_constants_1.LINE_BASIC_MATERIAL);
-exports.createEdgesForAGeometry = createEdgesForAGeometry;
+export const createEdgesForAGeometry = (figureGeometry) => new LineSegments(new EdgesGeometry(figureGeometry), LINE_BASIC_MATERIAL);
 /**
  * Dados los vértices de un poligono y una calidad para los vértices, devuelve
  * los vértices del poligono como un grupo
@@ -87,32 +78,30 @@ exports.createEdgesForAGeometry = createEdgesForAGeometry;
  * @param quality Calidad de las esferas de cada vertice
  * @returns Los vértices del poligono como un grupo
  */
-const createVertex = (vertices, quality) => {
+export const createVertex = (vertices, quality) => {
     const amountOfVertex = vertices.length;
-    const vertexGroup = new three_1.Group();
-    const geometry = new three_1.SphereGeometry(0.125, // Radio
+    const vertexGroup = new Group();
+    const geometry = new SphereGeometry(0.125, // Radio
     quality, quality);
     // Crea todas las esferas con el mismo estilo y las posiciona en la
     // correspondiente coordenada
     for (let i = 0; i < amountOfVertex; i = i + 3) {
-        const figureSphere = new three_1.Mesh(geometry, figures_constants_1.VERTEX_CONFIGURATION);
+        const figureSphere = new Mesh(geometry, VERTEX_CONFIGURATION);
         figureSphere.position.set(vertices[i], vertices[i + 1], vertices[i + 2]);
         vertexGroup.add(figureSphere);
     }
     return vertexGroup;
 };
-exports.createVertex = createVertex;
 /**
  * Dado un conjunto de puntos 3D, crea una linea punteada que los une.
  * @param points Conjunto de puntos 3D
  */
-const createDashedLine = (points) => {
+export const createDashedLine = (points) => {
     const pointsLine = [];
-    pointsLine.push(new three_1.Vector3(points[0].x, points[0].y, points[0].z));
-    pointsLine.push(new three_1.Vector3(points[1].x, points[1].y, points[1].z));
-    const geometry = new three_1.BufferGeometry().setFromPoints(pointsLine);
-    const line = new three_1.Line(geometry, figures_constants_1.LINE_DASHED_MATERIAL);
+    pointsLine.push(new Vector3(points[0].x, points[0].y, points[0].z));
+    pointsLine.push(new Vector3(points[1].x, points[1].y, points[1].z));
+    const geometry = new BufferGeometry().setFromPoints(pointsLine);
+    const line = new Line(geometry, LINE_DASHED_MATERIAL);
     line.computeLineDistances();
     return line;
 };
-exports.createDashedLine = createDashedLine;

--- a/src/figures-constants.ts
+++ b/src/figures-constants.ts
@@ -174,7 +174,21 @@ export const VERTEX_CONFIGURATION = new MeshLambertMaterial({
   transparent: true
 });
 
+// Se puede dar el caso en que se está renderizando una figura agrupada, esto
+// sucede cuando se usa joinFigIn3D. Para ver si el Group correspondiente es
+// el de las aristas, se chequea el material del primer elemento.
+// De ser ese el caso, se borra todo el Group (ya que solo tiene aristas)
+export const REMOVE_EDGES_PREDICATE = object3D =>
+  object3D.type === "LineSegments" ||
+  (object3D.type === "Group" &&
+    object3D.children[0]?.material?.type === "LineBasicMaterial");
+
 export const REMOVE_VERTEX_PREDICATE = object3D =>
   object3D.type === "Group" &&
   (object3D.children[0]?.geometry?.type === "SphereGeometry" ||
     object3D.children[0]?.children[0]?.geometry?.type === "SphereGeometry");
+
+export const REMOVE_METADATA_PREDICATE = object3D =>
+  object3D.material?.type === "LineDashedMaterial" ||
+  (object3D.type === "Group" &&
+    object3D.children[0]?.material?.type === "LineDashedMaterial");

--- a/src/graph3d.ts
+++ b/src/graph3d.ts
@@ -31,7 +31,11 @@ import {
   getFigureKey,
   createFigure3DVertex
 } from "./graph3d-utils";
-import { REMOVE_VERTEX_PREDICATE } from "./figures-constants";
+import {
+  REMOVE_EDGES_PREDICATE,
+  REMOVE_METADATA_PREDICATE,
+  REMOVE_VERTEX_PREDICATE
+} from "./figures-constants";
 // import { MathFunctionFigure, MathParametricFigure } from "./figures";
 
 const DEFAULT_AXES_WIDTH = { min: -10, max: 10 };
@@ -320,18 +324,8 @@ export function showEdges(visible: boolean) {
   if (visible) {
     showEdgesForEachRenderedFigure();
   } else {
-    // Se puede dar el caso en que se está renderizando una figura agrupada,
-    // esto sucede cuando se usa joinFigIn3D. Para ver si el Group
-    // correspondiente es el de las aristas, se chequea el primer elemento.
-    // De ser ese el caso, se borra todo el Group (ya que solo tiene aristas)
-    const predicateToRemove = object3D =>
-      object3D.type === "LineSegments" ||
-      (object3D.type === "Group" &&
-        (object3D.children[0]?.type === "LineSegments" ||
-          object3D.children[0]?.type === "Line"));
-
     /** Arreglo de objetos 3D que representan las aristas renderizadas */
-    const childrensToRemove = _group.children.filter(predicateToRemove);
+    const childrensToRemove = _group.children.filter(REMOVE_EDGES_PREDICATE);
 
     /* Si el anterior chequeo da problemas, se puede probar con la condición de filtrado:
         object3D instanceof
@@ -424,9 +418,6 @@ function showVertexForEachRenderedFigure() {
     if (figureVertex) {
       configureFigureInformationAndAddToTheScene(figure, figureVertex);
     }
-    // joinFigIn3D
-    // else if (figure.kind == "joinFigIn3D" && figure.f1.kind == "circle") {
-    //   figureRender = Figures.JoinFigIn3DFigure(figure, false);
   });
 }
 
@@ -455,11 +446,7 @@ export function showMetaData(visible: boolean) {
     // tiene material, pero depurando (haciendo console.log) se ve que algunos si tienen
     /** Arreglo de objetos 3D que representan la meta información renderizada */
     const childrensToRemove = (_group.children as any[]).filter(
-      object3D =>
-        (object3D.material &&
-          object3D.material.type === "LineDashedMaterial") ||
-        (object3D.type === "Group" &&
-          object3D.children[0]?.material.type === "LineDashedMaterial")
+      REMOVE_METADATA_PREDICATE
     );
 
     _group.remove(...childrensToRemove);
@@ -489,9 +476,6 @@ function showMetaDataForEachRenderedFigure() {
     if (figureMetaData) {
       configureFigureInformationAndAddToTheScene(figure, figureMetaData);
     }
-    // joinFigIn3D
-    // else if (figure.kind == "joinFigIn3D" && figure.f1.kind == "circle") {
-    //   figureRender = Figures.JoinFigIn3DFigure(figure, false);
   });
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "ES6",
     "target": "ES6",
     "allowJs": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
**Cambios que proponemos en este PR**:
 - Se ajustan los predicados.

 - Se migra el JavaScript generado por el TypeScript a ES6.